### PR TITLE
[Bugfix] Pass config to wandb, trace interval type check

### DIFF
--- a/vidur/config/config.py
+++ b/vidur/config/config.py
@@ -208,7 +208,7 @@ class SyntheticRequestGeneratorConfig(BaseRequestGeneratorConfig):
         metadata={"help": "Interval generator config for Synthetic Request Generator."},
     )
     num_requests: Optional[int] = field(
-        default=None,
+        default=128,
         metadata={"help": "Number of requests for Synthetic Request Generator."},
     )
     duration: Optional[float] = field(

--- a/vidur/metrics/metrics_store.py
+++ b/vidur/metrics/metrics_store.py
@@ -49,7 +49,9 @@ TIME_STR_MS = "Time (ms)"
 
 class MetricsStore:
 
-    def __init__(self, config: MetricsConfig, cluster_config: ClusterConfig, config_dict: Dict) -> None:
+    def __init__(
+        self, config: MetricsConfig, cluster_config: ClusterConfig, config_dict: Dict
+    ) -> None:
         self._config = config
         self._config_dict = config_dict
         self._last_request_arrived_at = None

--- a/vidur/metrics/metrics_store.py
+++ b/vidur/metrics/metrics_store.py
@@ -56,7 +56,9 @@ class MetricsStore:
 
         # copy config
         self._num_replicas = self._simulation_config.cluster_config.num_replicas
-        self._num_pipeline_stages = self._simulation_config.cluster_config.replica_config.num_pipeline_stages
+        self._num_pipeline_stages = (
+            self._simulation_config.cluster_config.replica_config.num_pipeline_stages
+        )
 
         # Initialise request metrics
         self._request_metrics_time_distributions: Dict[
@@ -196,7 +198,9 @@ class MetricsStore:
         # per replica stage metrics
         self._replica_busy_time = []
         self._replica_mfu = []
-        self._mfu_calculator = MFUCalculator(self._simulation_config.cluster_config.replica_config)
+        self._mfu_calculator = MFUCalculator(
+            self._simulation_config.cluster_config.replica_config
+        )
 
         for replica_idx in range(self._num_replicas):
             self._replica_memory_usage.append(

--- a/vidur/metrics/metrics_store.py
+++ b/vidur/metrics/metrics_store.py
@@ -49,8 +49,9 @@ TIME_STR_MS = "Time (ms)"
 
 class MetricsStore:
 
-    def __init__(self, config: MetricsConfig, cluster_config: ClusterConfig) -> None:
+    def __init__(self, config: MetricsConfig, cluster_config: ClusterConfig, config_dict: Dict) -> None:
         self._config = config
+        self._config_dict = config_dict
         self._last_request_arrived_at = None
 
         # copy config
@@ -243,7 +244,7 @@ class MetricsStore:
             project=self._config.wandb_project,
             group=self._config.wandb_group,
             name=self._config.wandb_run_name,
-            config=self._config.to_dict(),
+            config=self._config_dict,
         )
 
     def _save_as_csv(

--- a/vidur/request_generator/synthetic_request_generator.py
+++ b/vidur/request_generator/synthetic_request_generator.py
@@ -9,6 +9,7 @@ from vidur.request_generator.request_interval_generator_registry import (
 from vidur.request_generator.request_length_generator_registry import (
     RequestLengthGeneratorRegistry,
 )
+from vidur.types import RequestIntervalGeneratorType
 from vidur.utils.random import set_seeds
 
 
@@ -67,7 +68,7 @@ class SyntheticRequestGenerator(BaseRequestGenerator):
         else:
             assert (
                 self.config.interval_generator_config.get_type()
-                == RequestLengthGeneratorRegistry.TRACE
+                == RequestIntervalGeneratorType.TRACE
             )
 
             while True:
@@ -84,7 +85,7 @@ class SyntheticRequestGenerator(BaseRequestGenerator):
             self.config.duration
             or self.config.num_requests
             or self.config.interval_generator_config.get_type()
-            == RequestLengthGeneratorRegistry.TRACE
+            == RequestIntervalGeneratorType.TRACE
         )
 
         set_seeds(self.config.seed)

--- a/vidur/simulator.py
+++ b/vidur/simulator.py
@@ -34,11 +34,7 @@ class Simulator:
             self._config.metrics_config,
             self._config.request_generator_config,
         )
-        self._metric_store = MetricsStore(
-            config=self._config.metrics_config,
-            cluster_config=self._config.cluster_config,
-            config_dict=self._config.to_dict(),
-        )
+        self._metric_store = MetricsStore(self._config)
         self._request_generator = RequestGeneratorRegistry.get(
             self._config.request_generator_config.get_type(),
             self._config.request_generator_config,

--- a/vidur/simulator.py
+++ b/vidur/simulator.py
@@ -35,7 +35,9 @@ class Simulator:
             self._config.request_generator_config,
         )
         self._metric_store = MetricsStore(
-            self._config.metrics_config, self._config.cluster_config
+            config=self._config.metrics_config,
+            cluster_config=self._config.cluster_config,
+            config_dict=self._config.to_dict(),
         )
         self._request_generator = RequestGeneratorRegistry.get(
             self._config.request_generator_config.get_type(),


### PR DESCRIPTION
There were few bugs:
1. Passing `self._config.to_dict()` to config parameter of `wandb.init()` resulted in error, because `MetricsConfig` does not have `to_dict()` function.
2. Wrong type comparison for trace request interval generator type in `SyntheticRequestGenerator` class.
3. Simply running `python -m vidur.main` (without any CLI args) resulted in error mentioned in point 2. It tried to run vidur with trace request interval generator type, but we don't have dataset for that.

Fixes:
1. Directly pass SimulationConfig to MetricStore constructor.
2. Fixed type comparison with RequestIntervalGeneratorType enum.
3. Changed `num_requests` to some value instead of None for Synthetic request generator type, so that `python -m vidur.main` runs without any additional args.