### PR TITLE
Hybrid execution time predictor to solve extrapolation issues

### DIFF
--- a/vidur/config/config.py
+++ b/vidur/config/config.py
@@ -604,7 +604,69 @@ class RandomForrestExecutionTimePredictorConfig(BaseExecutionTimePredictorConfig
     @staticmethod
     def get_type():
         return ExecutionTimePredictorType.RANDOM_FORREST
-
+    
+@dataclass
+class HybridForestExecutionTimePredictorConfig(BaseExecutionTimePredictorConfig):
+    num_estimators: List[int] = field(
+        default_factory=lambda: [250, 500, 750],
+        metadata={"help": "Number of estimators for random forest."},
+    )
+    max_depth: List[int] = field(
+        default_factory=lambda: [8, 16, 32],
+        metadata={"help": "Maximum depth for random forest."},
+    )
+    min_samples_split: List[int] = field(
+        default_factory=lambda: [2, 5, 10],
+        metadata={"help": "Minimum samples split for random forest."},
+    )
+    # Boundary parameters
+    boundary_method : str = field(
+        default_factory=lambda: ["auto", "percentile"],
+        metadata={"help": "Method to determine boundaries."},
+    )
+    lower_boundary : float = field(
+        default_factory=lambda: [None],
+        metadata={"help": "Lower boundary for switching to linear regression."},
+    )
+    upper_boundary : float = field(
+        default_factory=lambda: [None],
+        metadata={"help": "Upper boundary for switching to linear regression."},
+    )
+    percentile_range : tuple = field(
+        default_factory=lambda: [(1, 99)],
+        metadata={"help": "Percentile range to use if boundary_method='percentile'."},
+    )
+    # rf_params : dict = field(
+    #     default=None,
+    #     metadata={"help": "Parameters to pass to RandomForestRegressor."},
+    # )
+    # lr_params : dict = field(
+    #     default=None,
+    #     metadata={"help": "Parameters to pass to LinearRegression."},
+    # )
+    feature_idx : int = field(
+        default_factory=lambda: [0], 
+        metadata={"help": "Index of the feature to use for boundary condition when X is multidimensional."},
+    )
+    polynomial_degree: List[int] = field(
+        default_factory=lambda: [1,2],
+        metadata={"help": "Polynomial degree for linear regression."},
+    )
+    polynomial_include_bias: List[bool] = field(
+        default_factory=lambda: [True],
+        metadata={"help": "Polynomial include bias for linear regression."},
+    )
+    polynomial_interaction_only: List[bool] = field(
+        default_factory=lambda: [True],
+        metadata={"help": "Polynomial interaction only for linear regression."},
+    )
+    fit_intercept: List[bool] = field(
+        default_factory=lambda: [True, False],
+        metadata={"help": "Fit intercept for linear regression."},
+    )
+    @staticmethod
+    def get_type():
+        return ExecutionTimePredictorType.HYBRID_FOREST
 
 @dataclass
 class ClusterConfig:
@@ -646,7 +708,7 @@ class SimulationConfig(ABC):
         metadata={"help": "Request generator config."},
     )
     execution_time_predictor_config: BaseExecutionTimePredictorConfig = field(
-        default_factory=RandomForrestExecutionTimePredictorConfig,
+        default_factory=HybridForestExecutionTimePredictorConfig,
         metadata={"help": "Execution time predictor config."},
     )
     metrics_config: MetricsConfig = field(

--- a/vidur/events/base_event.py
+++ b/vidur/events/base_event.py
@@ -30,6 +30,7 @@ class BaseEvent(ABC):
 
     @property
     def event_type(self):
+        return self._event_type
         pass
 
     @abstractmethod

--- a/vidur/execution_time_predictor/execution_time_predictor_registry.py
+++ b/vidur/execution_time_predictor/execution_time_predictor_registry.py
@@ -1,6 +1,9 @@
 from vidur.execution_time_predictor.linear_regression_execution_time_predictor import (
     LinearRegressionExecutionTimePredictor,
 )
+from vidur.execution_time_predictor.hybrid_execution_time_predictor import (
+    HybridForestExecutionTimePredictor,
+)
 from vidur.execution_time_predictor.random_forrest_execution_time_predictor import (
     RandomForrestExecutionTimePredictor,
 )
@@ -19,4 +22,8 @@ ExecutionTimePredictorRegistry.register(
 )
 ExecutionTimePredictorRegistry.register(
     ExecutionTimePredictorType.LINEAR_REGRESSION, LinearRegressionExecutionTimePredictor
+)
+
+ExecutionTimePredictorRegistry.register(
+    ExecutionTimePredictorType.HYBRID_FOREST, HybridForestExecutionTimePredictor
 )

--- a/vidur/execution_time_predictor/hybrid_execution_time_predictor.py
+++ b/vidur/execution_time_predictor/hybrid_execution_time_predictor.py
@@ -1,0 +1,297 @@
+import hashlib
+import os
+import pickle
+from abc import abstractmethod
+from itertools import product
+from typing import Any, Dict, List, Tuple
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import PolynomialFeatures
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import LinearRegression
+
+from vidur.config import (
+    HybridForestExecutionTimePredictorConfig,
+    BaseReplicaSchedulerConfig,
+    MetricsConfig,
+    ReplicaConfig,
+)
+from vidur.execution_time_predictor.sklearn_execution_time_predictor import (
+    SklearnExecutionTimePredictor,
+)
+
+from vidur.logger import init_logger
+
+logger = init_logger(__name__)
+
+class HybridForestLinearRegressor(BaseEstimator, RegressorMixin):
+    """
+    A hybrid model that uses RandomForestRegressor for interpolation within the training
+    data range and LinearRegression for extrapolation beyond specified boundaries.
+    
+    Parameters
+    ----------
+    boundary_method : str, default='auto'
+        Method to determine boundaries:
+        - 'auto': Use min/max values from training data
+        - 'percentile': Use percentiles of training data
+        - 'manual': Use manually specified boundaries
+    
+    lower_boundary : float or None, default=None
+        Lower boundary for switching to linear regression.
+        Required if boundary_method='manual'.
+    
+    upper_boundary : float or None, default=None
+        Upper boundary for switching to linear regression.
+        Required if boundary_method='manual'.
+    
+    percentile_range : tuple, default=(1, 99)
+        Percentile range to use if boundary_method='percentile'.
+    
+    n_estimators : int, default=100
+        Number of trees in the RandomForestRegressor.
+    
+    max_depth : int or None, default=None
+        Maximum depth of the trees in the RandomForestRegressor.
+    
+    min_samples_split : int, default=2
+        Minimum number of samples required to split an internal node in the RandomForestRegressor.
+    
+    lr_params : dict, default=None
+        Parameters to pass to LinearRegression.
+    
+    feature_idx : int, default=0
+        Index of the feature to use for boundary condition when X is multidimensional.
+
+    polynomial_degree : int, default=2
+        Degree of the polynomial features.
+        
+    polynomial_include_bias : bool, default=True
+        Whether to include a bias column in the polynomial features.
+    
+    polynomial_interaction_only : bool, default=True
+        Whether to include only interaction features in the polynomial features.
+    
+    fit_intercept : bool, default=True
+        Whether to fit an intercept in the LinearRegression model.
+ 
+    """
+    fit_intercept = True
+    # add all parameters
+    boundary_method = 'auto'
+    lower_boundary = None
+    upper_boundary = None
+    percentile_range = (1, 99)
+    n_estimators = None
+    max_depth = None
+    min_samples_split = 100
+    lr_params = None
+    feature_idx = 0
+    polynomial_degree = 2
+    polynomial_include_bias = True
+    polynomial_interaction_only = True
+    fit_intercept = True
+    
+    
+    def __init__(self, boundary_method='auto', lower_boundary=None, upper_boundary=None,
+                 percentile_range=(1, 99), n_estimators=None, max_depth=None, 
+                 min_samples_split=None, feature_idx=0, polynomial_degree=2,
+                 polynomial_include_bias=True, polynomial_interaction_only=True, fit_intercept=True):
+        
+        self.boundary_method = boundary_method
+        self.lower_boundary = lower_boundary
+        self.upper_boundary = upper_boundary
+        self.percentile_range = percentile_range
+        self.n_estimators = n_estimators
+        self.max_depth = max_depth
+        self.min_samples_split = min_samples_split
+        
+        self.feature_idx = feature_idx
+        self.polynomial_degree = polynomial_degree
+        self.polynomial_include_bias = polynomial_include_bias
+        self.polynomial_interaction_only = polynomial_interaction_only
+        self.fit_intercept = fit_intercept
+
+    def fit(self, X, y):
+        """
+        Fit the hybrid model to training data.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training input samples.
+        y : array-like of shape (n_samples,)
+            Target values.
+        
+        Returns
+        -------
+        self : object
+            Returns self.
+        """
+        # Initialize models
+        self.rf_model_ = RandomForestRegressor(
+            n_estimators=self.n_estimators,
+            max_depth=self.max_depth,
+            min_samples_split=self.min_samples_split
+        )
+        
+
+        self.poly_params =                                                       {
+            'degree': self.polynomial_degree,
+            'include_bias': self.polynomial_include_bias,
+            'interaction_only': self.polynomial_interaction_only
+        }
+        self.lr_params = {
+            'fit_intercept': self.fit_intercept
+        }
+        
+        self.lr_model_lower_ = make_pipeline(PolynomialFeatures(**self.poly_params),
+                                             LinearRegression(**self.lr_params))
+        
+        self.lr_model_upper_ = make_pipeline(PolynomialFeatures(**self.poly_params),
+                                             LinearRegression(**self.lr_params))
+
+        if isinstance(X, np.ndarray):
+            X_feature = X[:, self.feature_idx]
+
+        else:
+            col = X.columns[self.feature_idx]
+            X_feature = X[col]
+        
+        if self.boundary_method == 'auto':
+            self.lower_bound_ = np.min(X_feature)
+            self.upper_bound_ = np.max(X_feature)
+        elif self.boundary_method == 'percentile':
+            self.lower_bound_ = np.percentile(X_feature, self.percentile_range[0])
+            self.upper_bound_ = np.percentile(X_feature, self.percentile_range[1])
+        elif self.boundary_method == 'manual':
+            if self.lower_boundary is None or self.upper_boundary is None:
+                raise ValueError("When boundary_method='manual', both lower_boundary and "
+                                 "upper_boundary must be provided.")
+            self.lower_bound_ = self.lower_boundary
+            self.upper_bound_ = self.upper_boundary
+        else:
+            raise ValueError(f"Unknown boundary_method: {self.boundary_method}")
+        
+        # Fit Random Forest on all data
+        self.rf_model_.fit(X, y)
+        
+        # For lower boundary extrapolation
+        if isinstance(X, np.ndarray):
+            mask_lower = X_feature <= np.percentile(X_feature, 20)  # Use bottom 20% of data
+            X_lower = X[mask_lower]
+            y_lower = y[mask_lower]
+            # get all data, not just the feature column of X
+            
+            # self.lr_model_lower_ = LinearRegression(**self.lr_params)
+            self.lr_model_lower_.fit(X_lower, y_lower)
+            
+            # For upper boundary extrapolation
+            mask_upper = X_feature >= np.percentile(X_feature, 60)  # Use top 20% of data
+            X_upper = X[mask_upper]
+            y_upper = y[mask_upper]
+            self.lr_model_upper_.fit(X_upper, y_upper)
+            
+        # handle for dataframe X
+            
+        else:
+            mask_lower = X_feature <= np.percentile(X_feature, 20)  # Use bottom 20% of data
+            X_lower = X[mask_lower]
+            y_lower = y[mask_lower.to_list()]
+            self.lr_model_lower_.fit(X_lower, y_lower)
+            
+            # For upper boundary extrapolation
+            mask_upper = X_feature >= np.percentile(X_feature, 60)  # Use top 20% of data
+            X_upper = X[mask_upper]
+            y_upper = y[mask_upper.to_list()]
+            self.lr_model_upper_.fit(X_upper, y_upper)
+        return self
+
+
+    def predict(self, X):
+        """
+        Predict using the hybrid model.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Samples.
+            
+        Returns
+        -------
+        y : array-like of shape (n_samples,)
+            Returns predicted values.
+        """
+        # Check if the model has been fitted
+        if not hasattr(self, 'rf_model_'):
+            raise ValueError("This model has not been fitted yet. Call 'fit' before using 'predict'.")
+        
+        # Get the feature used for boundary condition
+        if isinstance(X, np.ndarray):
+            X_feature = X[:, self.feature_idx]
+        else:
+            X_feature = X.iloc[:, self.feature_idx]
+        
+        # Initialize prediction array
+        y_pred = np.zeros(X_feature.shape[0])
+        # Identify which samples fall into which region
+        mask_lower = X_feature < self.lower_bound_
+        mask_upper = X_feature > self.upper_bound_
+        mask_middle = ~(mask_lower | mask_upper)
+        
+        # Predict with appropriate model for each region
+        if np.any(mask_lower):
+            y_pred[mask_lower.to_list()] = self.lr_model_lower_.predict(X[mask_lower])
+        
+        if np.any(mask_upper):
+            y_pred[mask_upper.to_list()] = self.lr_model_upper_.predict(X[mask_upper])
+        
+        if np.any(mask_middle):
+            y_pred[mask_middle.to_list()] = self.rf_model_.predict(X[mask_middle])
+        
+        return y_pred
+    
+    def get_boundaries(self):
+        """Return the computed boundaries."""
+        if not hasattr(self, 'lower_bound_'):
+            raise ValueError("Boundaries not set. Call 'fit' first.")
+        return self.lower_bound_, self.upper_bound_
+
+
+class HybridForestExecutionTimePredictor(SklearnExecutionTimePredictor):
+    def __init__(
+        self,
+        predictor_config: HybridForestExecutionTimePredictorConfig,
+        replica_config: ReplicaConfig,
+        replica_scheduler_config: BaseReplicaSchedulerConfig,
+        metrics_config: MetricsConfig,
+    ) -> None:
+        # will trigger model training
+        super().__init__(
+            predictor_config=predictor_config,
+            replica_config=replica_config,
+            replica_scheduler_config=replica_scheduler_config,
+            metrics_config=metrics_config,
+        )
+
+    def _get_grid_search_params(self):
+        return {
+            "n_estimators": self._config.num_estimators,
+            "max_depth": self._config.max_depth,
+            "min_samples_split": self._config.min_samples_split,
+            "boundary_method": self._config.boundary_method,
+            "lower_boundary": self._config.lower_boundary,
+            "upper_boundary": self._config.upper_boundary,
+            "percentile_range": self._config.percentile_range,
+            "feature_idx": self._config.feature_idx,
+            "polynomial_degree": self._config.polynomial_degree,
+            "polynomial_include_bias": self._config.polynomial_include_bias,
+            "polynomial_interaction_only": self._config.polynomial_interaction_only,
+            "fit_intercept": self._config.fit_intercept,
+        }
+
+    def _get_estimator(self):
+        return HybridForestLinearRegressor()

--- a/vidur/execution_time_predictor/sklearn_execution_time_predictor.py
+++ b/vidur/execution_time_predictor/sklearn_execution_time_predictor.py
@@ -282,6 +282,7 @@ class SklearnExecutionTimePredictor(BaseExecutionTimePredictor):
         config_str = str(self.to_dict())
 
         if df is None:
+            # import pdb; pdb.set_trace()
             combined_str = f"{config_str}_{model_name}"
         else:
             df_hash_str = hashlib.md5(df.to_json().encode("utf-8")).hexdigest()

--- a/vidur/scheduler/replica_scheduler/vllm_replica_scheduler.py
+++ b/vidur/scheduler/replica_scheduler/vllm_replica_scheduler.py
@@ -76,17 +76,21 @@ class VLLMReplicaScheduler(BaseReplicaScheduler):
             next_num_tokens = self._get_request_next_num_tokens(request)
 
             if not self._can_allocate_request(request):
+                print("{} Cannot allocate request".format(request.id))
                 break
 
             new_num_tokens = num_tokens + [next_num_tokens]
             new_num_batch_tokens = len(new_num_tokens) * max(new_num_tokens)
             if new_num_batch_tokens > self._config.max_tokens_in_batch:
+                print("{} Batch size exceeds max_tokens_in_batch 85".format(request.id))
                 break
 
             if len(self._allocation_map) == self._config.batch_size_cap:
+                print("{} Batch size exceeds batch_size_cap 89".format(request.id))
                 break
 
             if len(requests) == self._max_micro_batch_size:
+                print("{} Batch size exceeds max_micro_batch_size 93".format(request.id))
                 break
 
             request = self._request_queue.pop(0)
@@ -95,6 +99,7 @@ class VLLMReplicaScheduler(BaseReplicaScheduler):
             requests.append(request)
             num_tokens.append(next_num_tokens)
             num_batch_tokens += next_num_tokens
+            
 
         if requests:
             return Batch(self._replica_id, requests, num_tokens)
@@ -104,6 +109,7 @@ class VLLMReplicaScheduler(BaseReplicaScheduler):
         # all preempted_requests will have prefill completed
         while self._preempted_requests:
             if len(requests) == self._max_micro_batch_size:
+                print("{} Batch size exceeds max_micro_batch_size (preempt 112)".format(request.id))
                 break
 
             request = self._preempted_requests.pop(0)
@@ -118,6 +124,7 @@ class VLLMReplicaScheduler(BaseReplicaScheduler):
                     request.restart()
                     self.free(request.id)
                     self._request_queue = [request] + self._request_queue
+                    print("{} No preempted requests to free (preempt 127)".format(request.id))
                     break
             else:
                 self._allocate_request(request)
@@ -126,6 +133,7 @@ class VLLMReplicaScheduler(BaseReplicaScheduler):
                 num_tokens.append(next_num_tokens)
 
         if not requests:
+            
             return
 
         return Batch(self._replica_id, requests, num_tokens)

--- a/vidur/types/execution_time_predictor_type.py
+++ b/vidur/types/execution_time_predictor_type.py
@@ -5,3 +5,4 @@ class ExecutionTimePredictorType(BaseIntEnum):
     DUMMY = 1
     RANDOM_FORREST = 2
     LINEAR_REGRESSION = 3
+    HYBRID_FOREST = 4


### PR DESCRIPTION
The current default random forest predictor is overfitting on the training set and is not able to generalize the batch execution time prediction to unseen token numbers or batch sizes. For example, it would use the largest time needed for the largest num_tokens for any other extrapolation. 

This causes inaccuracy of end-to-end latency, especially for long context sequences.

Prefill Latency (TTFT): 

| Predictor | 0.5 | 0.9 | 0.95 | 0.99 |
|-------|-----|-----|------|------|
| random-forest | 2.09 | 8.59 | 10.49 | 12.81 |
| hybrid-forest | 10.11 | 37.01 | 43.33 | 47.36 |

E2E Latency: 

| Predictor | 0.5 | 0.9 | 0.95 | 0.99 |
|-------|-----|-----|------|------|
| random-forest | 10.97 | 28.08 | 30.50 | 49.27 |
| hybrid-forest | 47.04 | 90.13 | 100.81 | 111.52 |

We verified that utilizing a polynomial fit for extrapolation along with a random forest for interpolation would yield the best MEAP results and bring them closest to the real system.  

